### PR TITLE
Fix production bug with wrong SQL charset

### DIFF
--- a/.env.prod.dist
+++ b/.env.prod.dist
@@ -16,3 +16,4 @@ TYPEORM_LOGGING=false
 TYPEORM_ENTITIES=dist/Entity/**/*.js
 TYPEORM_MIGRATIONS=dist/Migration/*.js
 TYPEORM_MIGRATIONS_DIR=src/Migration/
+TYPEORM_DRIVER_EXTRA='{"charset": "utf8mb4"}'

--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -1,4 +1,4 @@
-version: 0.1.3
+version: 0.1.4
 parameters:
     token: ~ # Your bot token
     commandPrefix: "!" # Commands prefix

--- a/infra/mysql/service.yml
+++ b/infra/mysql/service.yml
@@ -27,6 +27,10 @@ spec:
       containers:
         - image: mariadb:10.4.6
           name: mariadb
+          imagePullPolicy: Always
+          args:
+            - --character-set-server=utf8mb4
+            - --collation-server=utf8mb4_unicode_ci
           envFrom:
             - secretRef:
                 name: mysql-credential


### PR DESCRIPTION
# Description
After migrated on kubernetes i forgot to add the right SQL charset on dot env file. Without this information TypeORM is using default UTF8 charset and cannot persist unicode characters.